### PR TITLE
Make inline solving more flexible.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -268,12 +268,26 @@ export default class SolvePlugin extends Plugin {
 				` ${result} ` // Whitespace normalised for format.. Expression Result Comment
 			);
 		} else if (isInlineSolve) {
-			lineText = lineText.replace(
-				`s\`${expression}\``,
-				this.settings.inlineSolve.includeExpressionOnCommit
-					? `\`${expression} = ${result}\``
-					: `\`${result}\``
-			);
+			// Remove the equals from the result if the user does not want it.
+			const shouldIncludeEquals = this.settings.inlineSolve.includeEqualsOnCommit
+				&& !this.settings.inlineSolve.includeExpressionOnCommit;
+			let resultString = result.toString();
+			resultString = shouldIncludeEquals
+				? resultString
+				: resultString.replace(/^= /, "");
+
+			// Build the replacement text, adding the source expression if required.
+			let replacementText = this.settings.inlineSolve.includeExpressionOnCommit
+				? `${expression} = ${resultString}`
+				: `${resultString}`;
+
+			// Add the backticks if requested.
+			replacementText = this.settings.inlineSolve.includeBackticksOnCommit
+				? `\`${replacementText}\``
+				: replacementText;
+
+			// Build the full line replacement.
+			lineText = lineText.replace(`s\`${expression}\``, replacementText);
 		} else {
 			lineText = `${lineText?.trimEnd()} ${result}`;
 		}

--- a/src/settings/PluginSettings.ts
+++ b/src/settings/PluginSettings.ts
@@ -17,6 +17,8 @@ export const DEFAULT_SETTINGS: IPluginSettings = {
 
 	inlineSolve: {
 		includeExpressionOnCommit: false,
+		includeBackticksOnCommit: true,
+		includeEqualsOnCommit: true,
 	},
 
 	variable: {

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -88,6 +88,34 @@ export class SettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+		new Setting(this.containerEl)
+			.setName("Include backticks when committing")
+			.setDesc(`Solve will enclose the committed expression in backticks when committing. Default is ${DEFAULT_SETTINGS.inlineSolve.includeBackticksOnCommit}`)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.inlineSolve.includeBackticksOnCommit)
+					.onChange(async (value) => {
+						this.plugin.settings.inlineSolve.includeBackticksOnCommit =
+							value;
+
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(this.containerEl)
+			.setName("Include equals when committing")
+			.setDesc(`Solve will include the equals when committing. Has no effect if solve is set to include the expression. Default is ${DEFAULT_SETTINGS.inlineSolve.includeBackticksOnCommit}`)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.inlineSolve.includeEqualsOnCommit)
+					.onChange(async (value) => {
+						this.plugin.settings.inlineSolve.includeEqualsOnCommit =
+							value;
+
+						await this.plugin.saveSettings();
+					})
+			);
 	}
 
 	displayVariablesSettings() {

--- a/src/settings/definition/IInlineSolveSettings.ts
+++ b/src/settings/definition/IInlineSolveSettings.ts
@@ -1,3 +1,5 @@
 export interface IInlineSolveSettings {
 	includeExpressionOnCommit: boolean;
+	includeBackticksOnCommit: boolean;
+	includeEqualsOnCommit: boolean;
 }

--- a/src/settings/properties/InlineSolveSettings.ts
+++ b/src/settings/properties/InlineSolveSettings.ts
@@ -14,4 +14,26 @@ export class InlineSolveSettings {
 	set includeExpressionOnCommit(value: boolean) {
 		this.parent.settings.inlineSolve.includeExpressionOnCommit = value;
 	}
+
+	get includeBackticksOnCommit(): boolean {
+		return (
+			this.parent.settings.inlineSolve.includeBackticksOnCommit ??
+			DEFAULT_SETTINGS.inlineSolve.includeBackticksOnCommit
+		)
+	}
+
+	set includeBackticksOnCommit(value: boolean) {
+		this.parent.settings.inlineSolve.includeBackticksOnCommit = value;
+	}
+
+	get includeEqualsOnCommit(): boolean {
+		return (
+			this.parent.settings.inlineSolve.includeEqualsOnCommit ??
+			DEFAULT_SETTINGS.inlineSolve.includeEqualsOnCommit
+		)
+	}
+
+	set includeEqualsOnCommit(value: boolean) {
+		this.parent.settings.inlineSolve.includeEqualsOnCommit = value;
+	}
 }

--- a/src/utilities/Number.ts
+++ b/src/utilities/Number.ts
@@ -8,13 +8,13 @@ export function autoFormatIntegerOrFloat(
 		return includeThousandSeparators
 			? number.toLocaleString(decimalSeparatorLocale, {
 					maximumFractionDigits: 0,
-			  })
+			})
 			: Math.trunc(number);
 	}
 
 	return includeThousandSeparators
 		? number.toLocaleString(decimalSeparatorLocale, {
 				maximumFractionDigits: decimalPlaces,
-		  })
+		})
 		: number.toFixed(decimalPlaces);
 }


### PR DESCRIPTION
This commit adds two new configuration options for inline solving to tailor how the result is inserted into the user's note.

1. The first controls whether the backticks are inserted around the result expression.
2. The second controls whether the result expression includes the equals sign.