### PR TITLE
Add support for multiple inline expressions and fix #62

### DIFF
--- a/src/codemirror/MarkdownEditorViewPlugin.ts
+++ b/src/codemirror/MarkdownEditorViewPlugin.ts
@@ -95,7 +95,7 @@ export class MarkdownEditorViewPlugin implements PluginValue {
 			.addStage(this.variableProcessingStage)
 			.addStage(SharedExplicitModeRemovalStage)
 			.addStage(SharedVariableAssignRemovalStage);
-		
+
 		// Setup the post processor pipeline
 		this.resultProcessor = new StatefulPipeline<
 			[IProvider, AnyResult],

--- a/src/codemirror/MarkdownEditorViewPlugin.ts
+++ b/src/codemirror/MarkdownEditorViewPlugin.ts
@@ -201,7 +201,9 @@ export class MarkdownEditorViewPlugin implements PluginValue {
 
 				const line = view.state.doc.lineAt(linePosition);
 
-				let expression = line.text.trim();
+				let expression = line.text.trimStart();
+				let padding = line.text.length - expression.length;
+				expression = expression.trimEnd();
 
 				// Skip blank lines
 				if (!expression || expression.length === 0) {
@@ -255,6 +257,7 @@ export class MarkdownEditorViewPlugin implements PluginValue {
 								line.from + // Start of the line
 								3 + // Unaccounted inline solve characters s``
 								state.inlineSolveIndices[index] + // Position of the inline solve
+								padding + // Length of removed whitespace
 								inlineExpression.length; // Length of the inline solve
 
 							builder.add(

--- a/src/codemirror/MarkdownEditorViewPlugin.ts
+++ b/src/codemirror/MarkdownEditorViewPlugin.ts
@@ -241,7 +241,8 @@ export class MarkdownEditorViewPlugin implements PluginValue {
 					[expression]
 				);
 
-				inlineExpressions.forEach((inlineExpression, index) => {
+				for (let i = 0; i < inlineExpressions.length; i++) {
+					const inlineExpression = inlineExpressions[i]
 					expression = this.expressionProcesserFinal.process(
 						state,
 						inlineExpression
@@ -249,28 +250,29 @@ export class MarkdownEditorViewPlugin implements PluginValue {
 
 					// The line is valid and decoration can be provided.
 					const decoration = this.provideDecoration(state, expression);
-
-					if (decoration) {
-						if (state.isInlineSolve && state.inlineSolveIndices) {
-							// Result is displayed at the end of the inline solve position
-							const inlineSolvePosition =
-								line.from + // Start of the line
-								3 + // Unaccounted inline solve characters s``
-								state.inlineSolveIndices[index] + // Position of the inline solve
-								padding + // Length of removed whitespace
-								inlineExpression.length; // Length of the inline solve
-
-							builder.add(
-								inlineSolvePosition,
-								inlineSolvePosition,
-								decoration
-							);
-						} else {
-							// Result is displayed at the end of the line.
-							builder.add(line.to, line.to, decoration);
-						}
+					if (!decoration) {
+						continue;
 					}
-				})
+
+					if (state.isInlineSolve && state.inlineSolveIndices) {
+						// Result is displayed at the end of the inline solve position
+						const inlineSolvePosition =
+							line.from + // Start of the line
+							3 + // Unaccounted inline solve characters s``
+							state.inlineSolveIndices[i] + // Position of the inline solve
+							padding + // Length of removed whitespace
+							inlineExpression.length; // Length of the inline solve
+
+						builder.add(
+							inlineSolvePosition,
+							inlineSolvePosition,
+							decoration
+						);
+					} else {
+						// Result is displayed at the end of the line.
+						builder.add(line.to, line.to, decoration);
+					}
+				}
 
 				seenLines.add(line.number);
 				nextLineTextOffset += lineTextRaw.length;

--- a/src/pipelines/stages/expression/ExtractInlineSolveState.ts
+++ b/src/pipelines/stages/expression/ExtractInlineSolveState.ts
@@ -3,23 +3,28 @@ import { IExpressionProcessorState } from "@/pipelines/stages/expression/state/I
 
 export class ExtractInlineSolveStage extends BaseStatefulPipelineStage<
 	IExpressionProcessorState,
-	string
+	string[]
 > {
-	// Matches for either s`EXPRESSION` and will return the first instance.
-	private inlineSolveRegex = new RegExp(/s`([^`]*)`/);
+	// Matches for either s`EXPRESSION`.
+	private inlineSolveRegex = new RegExp(/s`([^`]*)`/g);
 
 	protected execute(
 		state: IExpressionProcessorState,
-		request: string
-	): string {
+		request: string[]
+	): string[] {
 		// IMPORTANT: We match the raw input expression and not the processed expression because
 		// 	          in cases where their is markdown elments e.g.lists, qouotes, etc...
-		const match = state.originalLineText.match(this.inlineSolveRegex);
+		const matches: string[] = [];
+		const indices: number[] = [];
+		for (const match of state.originalLineText.matchAll(this.inlineSolveRegex)) {
+			matches.push(match[1]);
+			indices.push(match.index);
+		}
 
-		if (match) {
+		if (matches.length > 0) {
 			state.isInlineSolve = true;
-			state.inlineSolveIndex = match.index;
-			return match[1];
+			state.inlineSolveIndices = indices;
+			return matches;
 		}
 
 		return request;

--- a/src/pipelines/stages/expression/ExtractInlineSolveState.ts
+++ b/src/pipelines/stages/expression/ExtractInlineSolveState.ts
@@ -13,7 +13,7 @@ export class ExtractInlineSolveStage extends BaseStatefulPipelineStage<
 		request: string[]
 	): string[] {
 		// IMPORTANT: We match the raw input expression and not the processed expression because
-		// 	          in cases where their is markdown elments e.g.lists, qouotes, etc...
+		// 	          in cases where there are markdown elements e.g.lists, quotes, etc...
 		const matches: string[] = [];
 		const indices: number[] = [];
 		for (const match of state.originalLineText.matchAll(this.inlineSolveRegex)) {

--- a/src/pipelines/stages/expression/ExtractInlineSolveState.ts
+++ b/src/pipelines/stages/expression/ExtractInlineSolveState.ts
@@ -18,7 +18,7 @@ export class ExtractInlineSolveStage extends BaseStatefulPipelineStage<
 		const indices: number[] = [];
 		for (const match of state.originalLineText.matchAll(this.inlineSolveRegex)) {
 			matches.push(match[1]);
-			indices.push(match.index);
+			indices.push(match.index!);
 		}
 
 		if (matches.length > 0) {

--- a/src/pipelines/stages/expression/PreviousResultSubstitutionStage.ts
+++ b/src/pipelines/stages/expression/PreviousResultSubstitutionStage.ts
@@ -21,7 +21,7 @@ export class PreviousResultSubstitutionStage extends BaseStatefulPipelineStage<
 		state: IExpressionProcessorState,
 		request: string
 	): string {
-		// If there is no previouds result then return the original request.
+		// If there is no previous result then return the original request.
 		if (this.previousResult === undefined) {
 			return request;
 		}

--- a/src/pipelines/stages/expression/state/IExpressionProcessorState.ts
+++ b/src/pipelines/stages/expression/state/IExpressionProcessorState.ts
@@ -4,7 +4,8 @@ export interface IExpressionProcessorState {
 
 	// Inline solve support
 	isInlineSolve?: boolean;
-	inlineSolveIndex?: number;
+	inlineSolveIndices?: number[];
+	inlineMatches?: string[];
 
 	// Explicit solve support
 	isAllowedExplicitModeExpression?: boolean;

--- a/test/pipeline/stages/ExtractInlineSolveStage.spec.ts
+++ b/test/pipeline/stages/ExtractInlineSolveStage.spec.ts
@@ -1,0 +1,48 @@
+import { ExtractInlineSolveStage } from "@/pipelines/stages/expression/ExtractInlineSolveState";
+import { IExpressionProcessorState } from "@/pipelines/stages/expression/state/IExpressionProcessorState";
+import { beforeAll, describe, expect, test } from "@jest/globals";
+
+let state: IExpressionProcessorState;
+let stage: ExtractInlineSolveStage;
+
+beforeAll(() => {
+	state = {
+		lineNumber: 0,
+		originalLineText: "",
+	};
+	stage = new ExtractInlineSolveStage();
+});
+
+describe("Inline Solve", () => {
+	test("Single Inline", () => {
+		const request = "s`1 + 2`";
+		state.originalLineText = request;
+		const result = stage.process(state, [request]);
+		expect(result).toBeDefined();
+		expect(result).toEqual(["1 + 2"]);
+	});
+
+	test("Multiple Inline", () => {
+		const request = "s`1 + 2` & s`2 - 1`";
+		state.originalLineText = request;
+		const result = stage.process(state, [request]);
+		expect(result).toBeDefined();
+		expect(result).toEqual(["1 + 2", "2 - 1"]);
+	});
+
+	test("Single Variable", () => {
+		const request = "s`:var + 1`";
+		state.originalLineText = request;
+		const result = stage.process(state, [request]);
+		expect(result).toBeDefined();
+		expect(result).toEqual([":var + 1"]);
+	});
+
+	test("Multiple Variables", () => {
+		const request = "s`:var + 1` & s`:var2 - 1`";
+		state.originalLineText = request;
+		const result = stage.process(state, [request]);
+		expect(result).toBeDefined();
+		expect(result).toEqual([":var + 1", ":var2 - 1"]);
+	});
+});


### PR DESCRIPTION
Fixes #62 and adds support for having multiple inline expressions in a single line.

Example usage:
```
:x = 100
:y = 20
Multiplication: s`:x * :y` Addition: s`:x + :y` Division s`:x / :y`
```

Will show up as:
```
:x = 100
:y = 20
Multiplication: s`:x * :y` = 2000 Addition: s`:x + :y` = 120 Division s`:x / :y` = 5
```

Screenshot:
![image](https://github.com/user-attachments/assets/3e596d1c-e27a-4319-9e5f-89df84727f12)


I split up the `expressionProcesser` into 3 variables.
There's now `expressionProcesser` which handles stages ```SharedMarkdownRemovalStage, SharedCommentsRemovalStage, SharedMathJaxRemovalStage```

Then `expressionProcesserArray` only runs `SharedExtractInlineSolveStage`

Finally `expressionProcesserFinal` runs ```previousResultSubstitutionStage, variableProcessingStage, SharedExplicitModeRemovalStage, SharedVariableAssignRemovalStage``` on all of the results returned from `expressionProcesserArray`

I couldn't think of a better way to handle this so let me know if you'd prefer it done another way.