### PR TITLE
ci: build and publish a release automatically on a solve-engine update

### DIFF
--- a/.github/workflows/engine-update.yml
+++ b/.github/workflows/engine-update.yml
@@ -3,17 +3,21 @@ name: Pick up a new solve-engine release
 # Two ways in:
 #   · repository_dispatch, fired by solve-engine's own publish workflow once
 #     a release has actually finished publishing to npm (see that repo's
-#     .github/workflows/publish.yml) — the normal path.
+#     .github/workflows/publish.yml) - the normal path.
 #   · workflow_dispatch, for testing this workflow directly without needing
 #     a real solve-engine release. Leave `version` blank to pick up
 #     whatever's currently on the npm registry.
 #
-# Either way, this only ever gets as far as bumping obsidian-solve's own
-# version and pushing a tag if `npm run build` and the test suite both pass
-# against the newly-installed engine. If they don't, the job just fails —
-# nothing is committed, no tag is created, nothing reaches users. Publishing
-# the resulting draft release (created by release.yml, triggered by the tag
-# push below) is still a separate, manual, deliberate act.
+# This only gets as far as bumping obsidian-solve's own version and pushing
+# a tag if `npm run build` and the test suite both pass against the newly
+# installed engine. If they don't, the job fails, nothing is committed, no
+# tag is created, and nothing reaches users.
+#
+# Pushing the tag is where this hands off: release.yml triggers on tag
+# pushes, builds the plugin and publishes the GitHub Release that Obsidian
+# clients actually read. This workflow deliberately does not create that
+# release itself. If it did, both this job and release.yml would race to
+# create the same one and whichever lost would fail the run.
 on:
     repository_dispatch:
         types: [solve-engine-released]
@@ -23,8 +27,15 @@ on:
                 description: "solve-engine version to install (blank = latest on npm)"
                 required: false
 
+# Nothing here uses GITHUB_TOKEN to write. See the checkout step for why.
 permissions:
-    contents: write
+    contents: read
+
+# Two releases of solve-engine landing close together would otherwise have
+# two copies of this racing for the same version bump and the same tag.
+concurrency:
+    group: engine-update
+    cancel-in-progress: false
 
 jobs:
     update:
@@ -34,6 +45,28 @@ jobs:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   ref: main
+                  # Full history. The push below is rejected from a shallow
+                  # clone, and the tag has to be created against real history
+                  # rather than a single grafted commit.
+                  fetch-depth: 0
+                  # Not GITHUB_TOKEN. Three separate things on this repository
+                  # refuse that token, and each one fails at a different point:
+                  #
+                  #   · `main` requires a pull request. Admins are exempt
+                  #     (enforce_admins is off) but `github-actions[bot]` is
+                  #     not an admin, so the push is rejected with GH006.
+                  #   · the "Auto-imported tag create protections" ruleset
+                  #     allows tag creation only for the admin role, so the
+                  #     tag is rejected too.
+                  #   · a tag pushed with GITHUB_TOKEN does not start a new
+                  #     workflow run, by design. release.yml would never fire
+                  #     and no release would be built, silently.
+                  #
+                  # A personal access token belonging to an admin clears all
+                  # three. persist-credentials leaves it configured as the
+                  # push credential for the steps below.
+                  token: ${{ secrets.ENGINE_UPDATE_TOKEN }}
+                  persist-credentials: true
 
             - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
@@ -42,33 +75,56 @@ jobs:
 
             - name: Resolve the target solve-engine version
               id: engine
+              env:
+                  DISPATCH_VERSION: ${{ github.event.client_payload.version }}
+                  INPUT_VERSION: ${{ inputs.version }}
               run: |
-                  version="${{ github.event.client_payload.version || inputs.version }}"
+                  version="${DISPATCH_VERSION:-$INPUT_VERSION}"
                   if [ -z "$version" ]; then
                     version="$(npm view solve-engine version)"
                   fi
                   echo "version=$version" >> "$GITHUB_OUTPUT"
+                  echo "Target solve-engine version: $version"
 
             - run: npm ci
 
             - name: Install the released solve-engine version
               run: npm install "solve-engine@${{ steps.engine.outputs.version }}"
 
+            # Re-running this for a version already installed should do
+            # nothing rather than mint an empty commit, a duplicate tag and a
+            # second release. That happens on a workflow_dispatch retry, and
+            # on a redelivered dispatch.
+            - name: Stop if the engine version did not change
+              id: changed
+              run: |
+                  if git diff --quiet -- package.json package-lock.json; then
+                    echo "Already on solve-engine ${{ steps.engine.outputs.version }}. Nothing to do."
+                    echo "changed=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "changed=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             # ══ SAFETY GATE ══ Nothing past this point runs unless both of
             # these succeed. A failure here means solve-engine shipped a
-            # breaking change obsidian-solve hasn't been updated for yet —
-            # exactly the class of issue today's manual migration surfaced
-            # (a rename, a widened config type, a build-target gap, a
-            # deprecated API removal). That needs a person, not an
-            # auto-merge.
-            - run: npm run build
-            - run: npm run test:ci
+            # breaking change obsidian-solve hasn't been updated for yet -
+            # exactly the class of issue the manual migration surfaced (a
+            # rename, a widened config type, a build-target gap, a deprecated
+            # API removal). That needs a person, not an auto-merge.
+            - if: steps.changed.outputs.changed == 'true'
+              run: npm run build
+
+            - if: steps.changed.outputs.changed == 'true'
+              run: npm run test:ci
 
             - name: Bump obsidian-solve's own version
+              if: steps.changed.outputs.changed == 'true'
               run: npm version patch --no-git-tag-version
 
             - name: Commit and tag
-              id: release
+              if: steps.changed.outputs.changed == 'true'
+              env:
+                  ENGINE_VERSION: ${{ steps.engine.outputs.version }}
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -76,8 +132,25 @@ jobs:
                   version="$(node -p "require('./package.json').version")"
                   tag="$version"
 
+                  # A tag that already exists means a previous run got this far
+                  # and something after it failed. Pushing main again is fine,
+                  # re-creating the tag is not.
+                  if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+                    echo "::error::Tag $tag already exists on the remote. Resolve by hand."
+                    exit 1
+                  fi
+
+                  # `npm version` ran the `version` lifecycle script, which is
+                  # `node version-bump.mjs && git add manifest.json versions.json`,
+                  # so those two are already staged.
                   git add package.json package-lock.json manifest.json versions.json
-                  git commit -m "chore: update to solve-engine ${{ steps.engine.outputs.version }}"
-                  git tag "$tag"
+                  git commit -m "chore: update to solve-engine ${ENGINE_VERSION}"
+
+                  # main first. If the tag went first and this were rejected,
+                  # there would be a tag pointing at a commit no branch
+                  # contains, and release.yml would already be building it.
                   git push origin main
+                  git tag "$tag"
                   git push origin "$tag"
+
+                  echo "Pushed $tag. release.yml takes it from here."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,13 @@
 name: Release Obsidian plugin
 
+# Triggered by a tag push. Two things push tags here:
+#
+#   · engine-update.yml, after a new solve-engine release passed its build
+#     and test gate - the automatic path.
+#   · a maintainer, by hand, for a release that isn't an engine bump.
+#
+# Either way this is the only place that builds and publishes the release,
+# so the two paths cannot race to create the same one.
 on:
     push:
         tags:
@@ -26,6 +34,28 @@ jobs:
                   npm ci
                   npm run build
 
+            # manifest.json is what Obsidian actually reads, and a release
+            # whose tag disagrees with it installs as the wrong version. The
+            # tag is the one thing here a person can typo, so it is checked
+            # against the tree rather than trusted.
+            - name: Check the tag against manifest.json
+              run: |
+                  tag="${GITHUB_REF#refs/tags/}"
+                  manifest="$(node -p "require('./manifest.json').version")"
+
+                  if [ "$tag" != "$manifest" ]; then
+                    echo "::error::Tag $tag does not match manifest.json version $manifest."
+                    exit 1
+                  fi
+
+                  echo "Tag $tag matches manifest.json."
+
+            # Published rather than a draft. Obsidian's community plugin list
+            # and BRAT both read published releases only, so a draft ships to
+            # nobody and waits on somebody remembering to press a button.
+            # This is now reached automatically from engine-update.yml, and
+            # the build and test gate over there is what stands between a
+            # solve-engine release and users.
             - name: Create release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,5 +64,5 @@ jobs:
 
                   gh release create "$tag" \
                     --title="$tag" \
-                    --draft \
+                    --latest \
                     main.js manifest.json styles.css


### PR DESCRIPTION
The chain from a `solve-engine` npm publish to a shipped plugin release has never once completed. It was broken in **five** places, each failing at a different point, and two of them failing silently.

## What was wrong

| # | Where | Failure |
| --- | --- | --- |
| 1 | solve-engine | `DISPATCH_OBSIDIAN_SOLVE` secret did not exist, so the dispatch never arrived. Log showed a blank `GH_TOKEN:` and `exit code 4`. |
| 2 | here | `git push origin main` rejected. `main` requires a PR and `github-actions[bot]` is not an admin, so `GH006`. |
| 3 | here | The "Auto-imported tag create protections" ruleset allows tag creation for the admin role only, so the tag would be rejected immediately after. |
| 4 | here | A tag pushed with `GITHUB_TOKEN` does not start a workflow run, by design. `release.yml` would never fire. **Silent.** |
| 5 | here | `release.yml` created the release with `--draft`. Obsidian's community plugin list and BRAT read published releases only, so it shipped to nobody. **Silent.** |

Only #2 ever surfaced as a red run ([32032674737](https://github.com/LiamRiddell/obsidian-solve/actions/runs/32032674737)). It got through build and tests, bumped the version, then died on the push. Because the step runs under `bash -e`, the tag push never ran either.

## What this does

Checking out with an admin PAT (`ENGINE_UPDATE_TOKEN`) clears #2, #3 and #4 at once: the push and the tag are both allowed, and a PAT-pushed tag *does* trigger `release.yml`. #5 becomes `--latest`.

Note the PR route was considered and rejected: `main` also has `require_code_owner_reviews` and `require_last_push_approval`, so a bot-authored PR would still need a human approver, which defeats the point.

`engine-update.yml` deliberately does **not** create the release itself. If it did, it and `release.yml` would race for the same one and whichever lost would fail the run. It pushes the tag and hands off.

## Also here

Hardening that only becomes reachable once this is automatic:

- an idempotency guard, so a redelivered dispatch or a re-run does not mint an empty commit, a duplicate tag and a second release
- a remote tag-existence check before pushing
- `main` pushed **before** the tag, so a rejected branch push cannot leave `release.yml` building a tag no branch contains
- a `concurrency` group, so two engine releases landing together do not race for the same version bump
- `release.yml` verifies the tag against `manifest.json`, since a mismatch installs as the wrong version in Obsidian

## Verified locally

- `npm run build` produces all three release assets (`main.js` 516 KB, `manifest.json`, `styles.css`)
- `npm version patch --no-git-tag-version` does run the `version` lifecycle script: bumped `manifest.json` to 2.0.2, appended to `versions.json`, staged both. So the tag always equals the manifest version, which the new check enforces.
- both workflow files parse

## Worth knowing before merging

This removes the last human checkpoint. Every `solve-engine` patch will build, tag and publish a plugin release, gated only by `npm run build` and `npm run test:ci`. That gate is real, but this is a deliberate change from the previous design, whose comments called publishing "a separate, manual, deliberate act".

🤖 Generated with [Claude Code](https://claude.com/claude-code)