### PR TITLE
Fix result commits in table cells

### DIFF
--- a/src/app/codemirror/MarkdownEditorViewPlugin.ts
+++ b/src/app/codemirror/MarkdownEditorViewPlugin.ts
@@ -331,7 +331,8 @@ export class MarkdownEditorViewPlugin implements PluginValue {
 					line,
 					expression,
 					this.formatResult(value),
-					isInline
+					isInline,
+					this.view
 				);
 				committed++;
 			}

--- a/src/app/codemirror/__tests__/CommitCommands.spec.ts
+++ b/src/app/codemirror/__tests__/CommitCommands.spec.ts
@@ -53,6 +53,7 @@ type CommitEvent = {
 	expression: string;
 	result: string;
 	isInlineSolve?: boolean;
+	sourceView?: unknown;
 };
 
 describe("MarkdownEditorViewPlugin.commitResults", () => {
@@ -62,9 +63,10 @@ describe("MarkdownEditorViewPlugin.commitResults", () => {
 		lineNumber: number,
 		expression: string,
 		result: string,
-		isInlineSolve?: boolean
+		isInlineSolve?: boolean,
+		sourceView?: unknown
 	) => {
-		captured.push({ lineNumber, expression, result, isInlineSolve });
+		captured.push({ lineNumber, expression, result, isInlineSolve, sourceView });
 	};
 
 	beforeEach(() => {
@@ -79,7 +81,8 @@ describe("MarkdownEditorViewPlugin.commitResults", () => {
 	});
 
 	test("commits an evaluated full-line expression", () => {
-		plugin = new MarkdownEditorViewPlugin(createMockView(["1 + 2"]));
+		const view = createMockView(["1 + 2"]);
+		plugin = new MarkdownEditorViewPlugin(view);
 
 		const committed = plugin.commitResults(1, 1);
 
@@ -90,6 +93,7 @@ describe("MarkdownEditorViewPlugin.commitResults", () => {
 		expect(captured[0].result.length).toBeGreaterThan(0);
 		expect(captured[0].result).toContain("3");
 		expect(captured[0].isInlineSolve).toBe(false);
+		expect(captured[0].sourceView).toBe(view);
 	});
 
 	test("returns 0 for lines without results (empty / markdown-only)", () => {

--- a/src/app/codemirror/__tests__/ResultCommit.spec.ts
+++ b/src/app/codemirror/__tests__/ResultCommit.spec.ts
@@ -1,0 +1,97 @@
+jest.mock("obsidian", () => ({
+	moment: () => undefined,
+	Plugin: class {},
+	PluginSettingTab: class {},
+}));
+
+import { pluginEventBus } from "@app/eventbus/PluginEventBus";
+import SolvePlugin from "@app/main";
+import { ExpressionResultWidget } from "@app/codemirror/widgets/ExpressionResultWidget";
+import { EditorState, TransactionSpec } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+
+class FakeElement {
+	public dataset: Record<string, string> = {};
+	public classList = { add: jest.fn() };
+	public style = { setProperty: jest.fn() };
+	public title = "";
+	public textContent = "";
+	private listeners = new Map<string, () => void>();
+
+	addEventListener(type: string, listener: () => void): void {
+		this.listeners.set(type, listener);
+	}
+
+	click(): void {
+		this.listeners.get("click")?.();
+	}
+}
+
+describe("result commits", () => {
+	const originalDocument = globalThis.document;
+
+	afterEach(() => {
+		pluginEventBus.removeAllListeners();
+		Object.defineProperty(globalThis, "document", {
+			configurable: true,
+			value: originalDocument,
+		});
+	});
+
+	it("commits a table-cell result through its originating view, not the global YAML editor", async () => {
+		const element = new FakeElement();
+		Object.defineProperty(globalThis, "document", {
+			configurable: true,
+			value: { createElement: () => element },
+		});
+
+		// Obsidian's table cell has a local CodeMirror document whose first
+		// line does not correspond to line 1 in the global active editor.
+		let sourceState = EditorState.create({ doc: "1 + 2" });
+		const sourceView = {
+			get state() {
+				return sourceState;
+			},
+			dispatch(spec: TransactionSpec) {
+				sourceState = sourceState.update(spec).state;
+			},
+		} as unknown as EditorView;
+
+		const yamlEditor = {
+			lines: ["---", "title: Example", "---"],
+			getLine(line: number) {
+				return this.lines[line];
+			},
+			setLine(line: number, text: string) {
+				this.lines[line] = text;
+			},
+		};
+
+		const plugin = Object.create(SolvePlugin.prototype) as SolvePlugin & {
+			registerEvents(): Promise<void>;
+		};
+		Object.assign(plugin, {
+			app: { workspace: { activeEditor: { editor: yamlEditor } } },
+			settings: {
+				inlineSolve: {
+					includeEqualsOnCommit: true,
+					includeExpressionOnCommit: false,
+					includeBackticksOnCommit: false,
+				},
+			},
+		});
+		await plugin.registerEvents();
+
+		const widget = new ExpressionResultWidget(1, false, "1 + 2", "= 3");
+		const rendered = widget.toDOM(sourceView) as unknown as FakeElement;
+		rendered.click();
+
+		expect({
+			source: sourceView.state.doc.toString(),
+			yaml: yamlEditor.lines,
+		}).toEqual({
+			source: "1 + 2 = 3",
+			yaml: ["---", "title: Example", "---"],
+		});
+	});
+});

--- a/src/app/codemirror/widgets/ExpressionResultWidget.ts
+++ b/src/app/codemirror/widgets/ExpressionResultWidget.ts
@@ -91,7 +91,8 @@ export class ExpressionResultWidget extends WidgetType {
 				this.lineNumber,
 				this.expression,
 				this.result,
-				this.isInlineSolve
+				this.isInlineSolve,
+				view
 			);
 		});
 

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -260,13 +260,25 @@ export default class SolvePlugin extends Plugin {
 		lineNumber: number,
 		expression: string,
 		result: string,
-		isInlineSolve?: boolean
+		isInlineSolve?: boolean,
+		sourceView?: EditorView
 	) {
 		const lineNumberZeroIndexed = Math.max(0, lineNumber - 1);
+		const sourceLine = sourceView
+			? lineNumber >= 1 && lineNumber <= sourceView.state.doc.lines
+				? sourceView.state.doc.line(lineNumber)
+				: undefined
+			: undefined;
 
-		let lineText = this.app.workspace.activeEditor?.editor?.getLine(
-			lineNumberZeroIndexed
-		);
+		if (sourceView && !sourceLine) {
+			return;
+		}
+
+		let lineText = sourceLine
+			? sourceLine.text
+			: this.app.workspace.activeEditor?.editor?.getLine(
+					lineNumberZeroIndexed
+				);
 
 		if (typeof lineText === "undefined") {
 			return;
@@ -310,6 +322,17 @@ export default class SolvePlugin extends Plugin {
 			lineText = lineText.replace(`s\`${expression}\``, replacementText);
 		} else {
 			lineText = `${lineText?.trimEnd()} ${result}`;
+		}
+
+		if (sourceView && sourceLine) {
+			sourceView.dispatch({
+				changes: {
+					from: sourceLine.from,
+					to: sourceLine.to,
+					insert: lineText,
+				},
+			});
+			return;
 		}
 
 		this.app.workspace.activeEditor?.editor?.setLine(


### PR DESCRIPTION
## Summary

- route result commits through the CodeMirror view that rendered them instead of resolving a view-local line number against the global active editor
- preserve existing comment, inline-solve, and full-line formatting behavior, with the active-editor path retained as a fallback
- add regression coverage proving a table-cell result updates its originating view without touching frontmatter, and keep command commits tied to their source view

## Testing

- `npm run test:ci` (7 suites, 100 tests)
- `npm run typecheck`
- `npm run build`
- focused ESLint on the new and changed logic/tests
- repository-wide ESLint reports only the pre-existing `no-constant-condition` finding in `MarkdownEditorViewPlugin.ts`
- `git diff --check`

Closes #66
